### PR TITLE
allow to get item by passing id inside params object

### DIFF
--- a/feathers/feathers.js
+++ b/feathers/feathers.js
@@ -24,6 +24,9 @@ module.exports = connect.behavior('data/feathers', function () {
       if (typeof params === 'string' || typeof params === 'number') {
         id = params;
         params = {};
+      } else if (params && typeof params[this.idProp] !== 'undefined') {
+        id = params[this.idProp];
+        delete params[this.idProp];
       }
       return service.get(id, params);
     },

--- a/feathers/feathers_tests-x-provider.js
+++ b/feathers/feathers_tests-x-provider.js
@@ -85,6 +85,21 @@ module.exports = function runProviderTests (options) {
       });
     });
 
+    QUnit.test('findOne with params', function (assert) {
+      var done = assert.async();
+
+      var message = new Message({
+        text: 'Hi there!'
+      });
+      message.save().then(function (msg) {
+        var id = msg._id;
+        Message.findOne({_id: id}).then(function (findResponse) {
+          assert.deepEqual(msg, findResponse, 'got same instance in find passing params');
+          done();
+        });
+      });
+    });
+
     QUnit.test('create', function (assert) {
       var done = assert.async();
       var message = new Message({

--- a/session/session_tests-x-provider.js
+++ b/session/session_tests-x-provider.js
@@ -188,7 +188,6 @@ module.exports = function runSessionTests (options) {
 
     QUnit.test('Session.get() returns a token payload after logged in', function (assert) {
       var done = assert.async();
-      // var validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZXhwIjozNDc2MzkyNDgwLCJpYXQiOjE0NzYzOTI0ODAsImlzcyI6ImZlYXRoZXJzIn0.0V6NKoNszBPeIA72xWs2FDW6aPxOnHzEmskulq20uyo';
 
       // Clear the token.
       app.logout();

--- a/session/session_tests-x-provider.js
+++ b/session/session_tests-x-provider.js
@@ -172,7 +172,7 @@ module.exports = function runSessionTests (options) {
 
     QUnit.test('Session.get() with no token returns NotAuthenticated error', function (assert) {
       var done = assert.async();
-      
+
       // Clear the token.
       app.logout();
 
@@ -188,7 +188,7 @@ module.exports = function runSessionTests (options) {
 
     QUnit.test('Session.get() returns a token payload after logged in', function (assert) {
       var done = assert.async();
-      var validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZXhwIjozNDc2MzkyNDgwLCJpYXQiOjE0NzYzOTI0ODAsImlzcyI6ImZlYXRoZXJzIn0.0V6NKoNszBPeIA72xWs2FDW6aPxOnHzEmskulq20uyo';
+      // var validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZXhwIjozNDc2MzkyNDgwLCJpYXQiOjE0NzYzOTI0ODAsImlzcyI6ImZlYXRoZXJzIn0.0V6NKoNszBPeIA72xWs2FDW6aPxOnHzEmskulq20uyo';
 
       // Clear the token.
       app.logout();


### PR DESCRIPTION
Allow to get item by passing id inside params object. This will allow to pass extra params, e.g. $populate, etc.

```js
MyModel.get({
    _id: 100,
    query: { $populate: ['myRef'] }
});
```