### PR TITLE
Convert ES6 features to ES5 code so that uglify will not choke

### DIFF
--- a/feathers/feathers.js
+++ b/feathers/feathers.js
@@ -9,17 +9,18 @@ module.exports = connect.behavior('data/feathers', function () {
   var service = this.feathersService;
 
   // Connect to realtime events.
-  service.on('created', message => this.createInstance(message));
-  service.on('updated', message => this.updateInstance(message));
-  service.on('patched', message => this.updateInstance(message));
-  service.on('removed', message => this.destroyInstance(message));
+  var self = this;
+  service.on('created', function(message){ self.createInstance(message); });
+  service.on('updated', function(message){ self.updateInstance(message); });
+  service.on('patched', function(message){ self.updateInstance(message); });
+  service.on('removed', function(message){ self.destroyInstance(message); });
 
   return {
-    getListData (params) {
+    getListData: function(params) {
       return service.find(params);
     },
 
-    getData (params) {
+    getData: function(params) {
       var id = null;
       if (typeof params === 'string' || typeof params === 'number') {
         id = params;
@@ -31,15 +32,15 @@ module.exports = connect.behavior('data/feathers', function () {
       return service.get(id, params);
     },
 
-    createData (data) {
+    createData: function(data) {
       return service.create(data);
     },
 
-    updateData (instance) {
+    updateData: function(instance) {
       return service.update(instance[this.idProp], instance);
     },
 
-    destroyData (instance) {
+    destroyData: function(instance) {
       return service.remove(instance[this.idProp]);
     }
   };

--- a/session/session.js
+++ b/session/session.js
@@ -2,7 +2,7 @@ var connect = require('can-connect');
 var errors = require('feathers-errors');
 
 module.exports = connect.behavior('data/feathers-session', function () {
-  let helpURL = 'http://canjs.github.io/canjs/doc/can-connect-feathers.html';
+  var helpURL = 'http://canjs.github.io/canjs/doc/can-connect-feathers.html';
   if (!this.feathersApp) {
     throw new Error('You must provide a feathersApp instance to the feathersSession behavior. See ' + helpURL);
   }
@@ -14,7 +14,7 @@ module.exports = connect.behavior('data/feathers-session', function () {
   var app = this.feathersApp;
 
   return {
-    createData (data) {
+    createData: function(data) {
       return new Promise(function (resolve, reject) {
         return app.authenticate(data)
           .then(app.authentication.verifyJWT)
@@ -24,7 +24,7 @@ module.exports = connect.behavior('data/feathers-session', function () {
           .catch(reject);
       });
     },
-    getData () {
+    getData: function() {
       return new Promise(function (resolve, reject) {
         app.authentication.getJWT()
         .then(function (data) {
@@ -35,7 +35,7 @@ module.exports = connect.behavior('data/feathers-session', function () {
         });
       });
     },
-    destroyData () {
+    destroyData: function() {
       return app.logout();
     }
   };


### PR DESCRIPTION
Fixes #27 

This PR leaves a bad taste in my mouth, but it is the easiest way to move forward until we can implement a better solution.

This just converts ES6 features to ES5, but we should really consider a build step to do this for us so we can continue to use ES6 in the source code.