### PR TITLE
Switch to internal can-zone-storage module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "mocha"
     ]
   },
-  "main": "dist/cjs/can-connect-feathers",
+  "main": "can-connect-feathers",
   "keywords": [
     "canjs",
     "can",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
     "document": "documentjs",
     "develop": "done-serve --static --develop --port 8080"
   },
-  "semistandard": {
-    "envs": [
-      "mocha"
-    ]
-  },
-  "main": "can-connect-feathers",
+  "main": "dist/cjs/can-connect-feathers",
   "keywords": [
     "canjs",
     "can",

--- a/session/session.js
+++ b/session/session.js
@@ -6,7 +6,7 @@ var payloadIsValid = require('../utils/utils').payloadIsValid;
 var hasValidToken = require('../utils/utils').hasValidToken;
 var convertLocalAuthData = require('../utils/utils').convertLocalAuthData;
 var Observation = require('can-observation');
-var zoneStorage = require('can-zone-storage');
+var zoneStorage = require('./storage');
 
 module.exports = connect.behavior('data/feathers-session', function () {
 	var helpURL = 'https://canjs.com/doc/can-connect-feathers.html';

--- a/session/storage.js
+++ b/session/storage.js
@@ -1,0 +1,26 @@
+module.exports = {
+  data: {},
+
+  getStore: function () {
+    if (window.doneSsr) {
+      var CanZone = window.CanZone || undefined;
+      return typeof CanZone === 'undefined' ? this.data : CanZone.current.data;
+    }
+    return this.data;
+  },
+
+  setItem: function (prop, value) {
+    var store = this.getStore();
+    store[prop] = value;
+  },
+
+  getItem: function (prop) {
+    var store = this.getStore();
+    return store[prop];
+  },
+
+  removeItem: function (prop) {
+    var store = this.getStore();
+    delete store[prop];
+  }
+};


### PR DESCRIPTION
This (hopefully temporarily) switches the zone storage to use a local copy until a bug is worked out in `can-zone-storage` related to the browser.