### PR TITLE
call session.get() only if session.current is undefined (not null)

### DIFF
--- a/session/session.js
+++ b/session/session.js
@@ -28,9 +28,9 @@ module.exports = connect.behavior('data/feathers-session', function () {
 	Object.defineProperty(Session, 'current', {
 		get: function () {
 			Observation.add(Session, 'current');
-			if (!zoneStorage.getItem('can-connect-feathers-session')) {
+			if (zoneStorage.getItem('can-connect-feathers-session') === undefined) {
 
-				// set session to `undefined` when we start authentication (in case it was already `null`):
+				// set session to `undefined` when we start authentication:
 				zoneStorage.removeItem('can-connect-feathers-session');
 				
 				Session.get().then(function (session) {

--- a/session/session_tests-x-provider.js
+++ b/session/session_tests-x-provider.js
@@ -418,7 +418,7 @@ module.exports = function runSessionTests (options) {
 	QUnit.test('Session.current states', function(assert){
 		var done = assert.async();
 		
-		assert.ok(Session.current === undefined, 'Session.current should be undefined');
+		assert.ok(!Session.current, 'Session.current should be null or undefined');
 		
 		var handler = function(ev, value){
 			assert.ok(value === null, 'Session.current should be null for non-authenticated');


### PR DESCRIPTION
otherwise we are getting into an infinite loop between `Session.current` getter and an external subscriber.