### PR TITLE
Allow 2FA scenarios in auth response

### DIFF
--- a/session/session.js
+++ b/session/session.js
@@ -85,7 +85,7 @@ module.exports = connect.behavior('data/feathers-session', function () {
 			var requestData = convertLocalAuthData(data);
 			return feathersClient.authenticate(requestData)
 				.then(function (response) {
-					return decode(response.accessToken);
+					return response.accessToken ? decode(response.accessToken) : response;
 				});
 		},
 		getData: function () {

--- a/session/session_test.js
+++ b/session/session_test.js
@@ -51,7 +51,9 @@ function getUserFromStore (authData) {
 }
 var authRestHandler = function (request, response) {
 	var authData = request.data;
-	if (authData && authData.email) {
+	if (authData && authData.isTwoFactorAuthExample) {
+		response({success: true});
+	} else if (authData && authData.email) {
 		var user = getUserFromStore(authData);
 		if (user) {
 			document.cookie = 'feathers-jwt=' + accessToken;
@@ -125,6 +127,11 @@ runCrossProviderTests({
 			if (request.strategy === 'jwt') {
 				return authenticatedUser();
 			}
+
+			if (request.isTwoFactorAuthExample) {
+				callback(null, {success: true});
+			}
+
 			var user = getUserFromStore(request);
 			if (user) {
 				return authenticatedUser();


### PR DESCRIPTION
With two-factor authentication, we won’t get back an accessToken after the first factor is authenticated (email/password, for example).  The session behavior has been updated to only try to decode an accessToken if one exists, otherwise it will return whatever response is given by the server.