### PR TITLE
Feature: Async Connection via async feathersClient

### DIFF
--- a/service/service.js
+++ b/service/service.js
@@ -18,16 +18,18 @@ module.exports = connect.behavior('data/feathers-service', function () {
 		throw new Error('You must provide a feathersService to the feathers-service behavior: ' + helpURL);
 	}
 
-	var service = this.feathersService;
+	var service = Promise.resolve(this.feathersService);
 
 	return {
-		init: function () {
+		init: function () {			
 			var self = this;
 			// Connect to real-time events.
-			service.on('created', function (message) { self.createInstance(message); });
-			service.on('updated', function (message) { self.updateInstance(message); });
-			service.on('patched', function (message) { self.updateInstance(message); });
-			service.on('removed', function (message) { self.destroyInstance(message); });
+		        service.then(instance=>{
+			  instance.on('created', function (message) { self.createInstance(message); });
+			  instance.on('updated', function (message) { self.updateInstance(message); });
+			  instance.on('patched', function (message) { self.updateInstance(message); });
+			  instance.on('removed', function (message) { self.destroyInstance(message); });
+		        });
 		},
 
 		getListData: function (params) {


### PR DESCRIPTION
This changes nothing from the existing API it adds only the option to supply a promise as feathers client i need this feature and think its usefull for any one who does newer coding styles and does things like i do:

frathers-client-async.js

```
/* global window */
import loader from '@loader';

let clientUrl;

if (window && window.fetch) {
  clientUrl = '~/models/feathers/v3/feathers-client.socketio.js';
} else {
  clientUrl = '~/models/feathers/v3/feathers-client.rest.js';
} 

export const feathersClient = loader.import(clientUrl).then((module)=>{ return module.feathersClient; }, err=>{
  new Error('Feathers-client Error '+ clientUrl,err);
}); 


export default feathersClient;
```