### PR TITLE
Return full response object after authentication

### DIFF
--- a/session/session.js
+++ b/session/session.js
@@ -86,7 +86,10 @@ module.exports = connect.behavior('data/feathers-session', function (base) {
 			var requestData = convertLocalAuthData(data);
 			return feathersClient.authenticate(requestData)
 				.then(function (response) {
-					return response.accessToken ? decode(response.accessToken) : response;
+					if (response.accessToken) {
+						Object.assign(response, decode(response.accessToken));
+					}
+					return response;
 				});
 		},
 		getData: function () {

--- a/session/session_tests-x-provider.js
+++ b/session/session_tests-x-provider.js
@@ -203,6 +203,7 @@ module.exports = function runSessionTests (options) {
 				session.save()
 				.then(function (res) {
 					assert.ok(res._id, 'Got session data back');
+					assert.ok(res.accessToken, 'Got full response data back');
 					Session.get()
 					.then(function (res) {
 						assert.ok(res._id, 'Session.get returned session data');


### PR DESCRIPTION
closes #89 
This allows the authentication response to return other data alongside the auth token (jwt). This is particularly useful for allowing the user object to be returned during authentication. Without this code, the client has to make a second request for the user.