### PR TITLE
Use can-observation-recorder instead of can-observation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "can-assign": "^1.0.0",
-    "can-observation": "^4.0.0",
+    "can-observation-recorder": "^1.0.0",
     "can-zone-storage": "^1.0.0",
     "feathers-authentication-popups": "^0.1.2",
     "feathers-errors": "^2.7.0",

--- a/session/session.js
+++ b/session/session.js
@@ -5,7 +5,7 @@ var decode = require('jwt-decode');
 var payloadIsValid = require('../utils/utils').payloadIsValid;
 var hasValidToken = require('../utils/utils').hasValidToken;
 var convertLocalAuthData = require('../utils/utils').convertLocalAuthData;
-var Observation = require('can-observation');
+var ObservationRecorder = require('can-observation-recorder');
 var zoneStorage = require('./storage');
 
 module.exports = connect.behavior('data/feathers-session', function (base) {
@@ -27,7 +27,7 @@ module.exports = connect.behavior('data/feathers-session', function (base) {
 
 	Object.defineProperty(Session, 'current', {
 		get: function () {
-			Observation.add(Session, 'current');
+			ObservationRecorder.add(Session, 'current');
 			if (zoneStorage.getItem('can-connect-feathers-session') === undefined) {
 
 				// set session to `undefined` when we start authentication:


### PR DESCRIPTION
This fixes a warning that appeared by calling can-observation’s add() method.